### PR TITLE
Support for writing feed info with pages

### DIFF
--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.png" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -128,11 +128,11 @@
 	</build>
 
 	<dependencies>
-		<dependency>
-			<groupId>rome</groupId>
-			<artifactId>rome</artifactId>
-			<version>1.0</version>
-		</dependency>
+        <dependency>
+            <groupId>com.rometools</groupId>
+            <artifactId>rome</artifactId>
+            <version>1.5.1</version>
+        </dependency>
 		<dependency>
 			<groupId>org.archive.heritrix</groupId>
 			<artifactId>heritrix-commons</artifactId>

--- a/src/main/java/is/landsbokasafn/crawler/rss/CxmlConfigurationManager.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/CxmlConfigurationManager.java
@@ -18,11 +18,11 @@
  */
 package is.landsbokasafn.crawler.rss;
 
-import java.util.Collection;
-
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+
+import java.util.Collection;
 
 /**
  * Default RSS configuration manager. Assumes that RssSite beans have been defined in the Heritrix CXML

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssAttributeConstants.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssAttributeConstants.java
@@ -26,5 +26,6 @@ public interface RssAttributeConstants {
     
     public static final String LAST_CONTENT_DIGEST = "lastContentDigest";
     public static final String LAST_FETCH_TIME = "lastFetchTime";
+    public static final String RSS_DATA = "rssData";
 	
 }

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssBdbUriUniqFilter.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssBdbUriUniqFilter.java
@@ -18,13 +18,13 @@
  */
 package is.landsbokasafn.crawler.rss;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.archive.crawler.util.BdbUriUniqFilter;
 import org.archive.crawler.util.BloomUriUniqFilter;
 import org.archive.crawler.util.SetBasedUriUniqFilter;
 import org.archive.modules.CrawlURI;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A variant on the {@link BdbUriUniqFilter} that supports {@link DuplicateReceiver}.

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssBloomUriUniqFilter.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssBloomUriUniqFilter.java
@@ -18,13 +18,13 @@
  */
 package is.landsbokasafn.crawler.rss;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.archive.crawler.util.BdbUriUniqFilter;
 import org.archive.crawler.util.BloomUriUniqFilter;
 import org.archive.crawler.util.SetBasedUriUniqFilter;
 import org.archive.modules.CrawlURI;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A variant on the {@link BloomUriUniqFilter} that supports {@link DuplicateReceiver}.

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
@@ -18,20 +18,6 @@
  */
 package is.landsbokasafn.crawler.rss;
 
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_IMPLIED_LINKS;
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_MOST_RECENTLY_SEEN;
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_SITE;
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_URI_TYPE;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.annotation.PostConstruct;
-
 import org.apache.commons.lang.NotImplementedException;
 import org.archive.crawler.datamodel.UriUniqFilter;
 import org.archive.crawler.event.CrawlURIDispositionEvent;
@@ -44,6 +30,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.Lifecycle;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static is.landsbokasafn.crawler.rss.RssAttributeConstants.*;
 
 public class RssCrawlController implements
 			DuplicateReceiver,

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
@@ -339,6 +339,7 @@ public class RssCrawlController implements
 		
 		sb.append("RssCrawlController report \n");
 		sb.append("  Controller state: " + (started?(shouldStop?"should stop":"running"):"not started") + "\n");
+        sb.append("  Controller state: " + this.controller != null ? controller.getState().toString() : "null");
 		sb.append(frontier.isRunning()?"  Frontier is running":"  Frontier is not running");
 		sb.append("\n");
 		

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
@@ -205,7 +205,7 @@ public class RssCrawlController implements
 		while (!shouldStop) {
 			State state = (State)controller.getState();
 			if (state==State.RUNNING || state==State.EMPTY) {
-				if (false && recheckConfig && System.currentTimeMillis()>lastCheckedConfig+checkConfigIntervalMs) {
+				if (recheckConfig && System.currentTimeMillis()>lastCheckedConfig+checkConfigIntervalMs) {
 					readConfig(); // Check for new sites
 					// Trigger updates in all WAITING and ENDED sites
 					for (RssSite site : sites.values()) {

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
@@ -210,7 +210,7 @@ public class RssCrawlController implements
 					// Trigger updates in all WAITING and ENDED sites
 					for (RssSite site : sites.values()) {
 						if (site.getState()==RssSiteState.WAITING || site.getState()==RssSiteState.ENDED) {
-							site.doUpdate();
+						//	site.doUpdate();
 						}
 					}
 					lastCheckedConfig=System.currentTimeMillis();
@@ -339,7 +339,7 @@ public class RssCrawlController implements
 		
 		sb.append("RssCrawlController report \n");
 		sb.append("  Controller state: " + (started?(shouldStop?"should stop":"running"):"not started") + "\n");
-        sb.append("  Controller state: " + this.controller != null ? controller.getState().toString() : "null");
+        sb.append("  Controller state: " + (this.controller != null ? controller.getState().toString() : "null") + "\n");
 		sb.append(frontier.isRunning()?"  Frontier is running":"  Frontier is not running");
 		sb.append("\n");
 		

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlController.java
@@ -205,12 +205,12 @@ public class RssCrawlController implements
 		while (!shouldStop) {
 			State state = (State)controller.getState();
 			if (state==State.RUNNING || state==State.EMPTY) {
-				if (recheckConfig && System.currentTimeMillis()>lastCheckedConfig+checkConfigIntervalMs) {
+				if (false && recheckConfig && System.currentTimeMillis()>lastCheckedConfig+checkConfigIntervalMs) {
 					readConfig(); // Check for new sites
 					// Trigger updates in all WAITING and ENDED sites
 					for (RssSite site : sites.values()) {
 						if (site.getState()==RssSiteState.WAITING || site.getState()==RssSiteState.ENDED) {
-						//	site.doUpdate();
+							site.doUpdate();
 						}
 					}
 					lastCheckedConfig=System.currentTimeMillis();

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlReport.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssCrawlReport.java
@@ -1,10 +1,10 @@
 package is.landsbokasafn.crawler.rss;
 
-import java.io.PrintWriter;
-
 import org.archive.crawler.reporting.Report;
 import org.archive.crawler.reporting.StatisticsTracker;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.PrintWriter;
 
 public class RssCrawlReport extends Report {
 

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssEntry.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssEntry.java
@@ -1,0 +1,60 @@
+package is.landsbokasafn.crawler.rss;
+
+import com.rometools.rome.feed.synd.SyndCategory;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndPerson;
+
+/**
+ * Created by abhijit on 04/11/15.
+ */
+public class RssEntry {
+    public final String link;
+    public final String title;
+    public final List<String> author;
+    public final String description;
+    public final List<String> categories;
+    public final Date date;
+
+//    public RssEntry(String link, String title, List<String> author, String description, String categories, Date date) {
+//        this.link = link;
+//        this.title = title;
+//        this.author = author;
+//        this.description = description;
+//        this.categories = categories;
+//        this.date = date;
+//    }
+
+    public RssEntry(SyndEntry entry) {
+        this.link = entry.getLink();
+        this.title = entry.getTitle();
+        this.author = new ArrayList<String>(entry.getAuthors().size());
+        for (SyndPerson person : entry.getAuthors() )
+            this.author.add(person.getName());
+
+        this.categories = new ArrayList<String>(entry.getCategories().size());
+        for (SyndCategory category : entry.getCategories())
+            this.categories.add(category.getName());
+
+        this.date = entry.getPublishedDate();
+        this.description = entry.getDescription().getValue();
+    }
+
+    public Map<String, String> getRecords() {
+        Map<String, String> map = new HashMap<String, String>();
+        String[][] vals = new String[][] {
+                { "link", this.link },
+                { "title" , this.title},
+                { "author", this.author.toString()},
+                { "categories", this.categories.toString()},
+                { "date", this.date.toString() },
+                { "description", this.description }
+        };
+
+        for (String[] val : vals) {
+            if (vals[1] != null)
+                map.put(val[0], val[1]);
+        }
+
+        return map;
+    }
+}

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssExtractor.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssExtractor.java
@@ -24,10 +24,15 @@ import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_URI_TYPE;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.FeedException;
 import org.apache.commons.io.IOUtils;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.extractor.Extractor;
@@ -35,11 +40,8 @@ import org.archive.modules.extractor.Hop;
 import org.archive.modules.extractor.LinkContext;
 import org.archive.modules.revisit.IdenticalPayloadDigestRevisit;
 
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.io.FeedException;
-import com.sun.syndication.io.SyndFeedInput;
-import com.sun.syndication.io.XmlReader;
+
+import com.rometools.rome.io.SyndFeedInput;
 
 public class RssExtractor extends Extractor {
     private static final Logger log = Logger.getLogger(RssExtractor.class.getName());
@@ -47,7 +49,7 @@ public class RssExtractor extends Extractor {
 	@SuppressWarnings("unchecked")
 	@Override
 	protected void extract(CrawlURI curi) {
-	    XmlReader reader = null;
+        InputStreamReader reader = null;
         InputStream instream = null;
         
         checkIfDuplicate(curi);
@@ -60,7 +62,7 @@ public class RssExtractor extends Extractor {
         try {
             instream = curi.getRecorder().getContentReplayInputStream();
 		 
-			reader = new XmlReader(instream);
+			reader = new InputStreamReader(instream);
 			SyndFeed feed = new SyndFeedInput().build(reader);
 			Object mrs = curi.getData().get(RssAttributeConstants.RSS_MOST_RECENTLY_SEEN);
 			if (mrs==null) {

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssExtractor.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssExtractor.java
@@ -77,6 +77,7 @@ public class RssExtractor extends Extractor {
 				log.fine("Processing Entry " + entry.getTitle());
 				if (entry.getLink()!=null) {
 					Date date = entry.getUpdatedDate();
+
 					if (date==null) {
 						date = entry.getPublishedDate();
 					}

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssExtractor.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssExtractor.java
@@ -76,7 +76,7 @@ public class RssExtractor extends Extractor {
 
 			for (Object o : feed.getEntries()) {
 				SyndEntry entry = (SyndEntry)o;
-				log.fine("Processing Entry " + entry.getTitle());
+				log.fine("Processing Entry " + (entry.getTitle() == null ? "" : entry.getTitle()));
 				if (entry.getLink()!=null) {
 					Date date = entry.getUpdatedDate();
 
@@ -85,7 +85,7 @@ public class RssExtractor extends Extractor {
 					}
 					if (date==null) {
 						log.warning("Skipping item with no date for item in feed " + curi.getURI());
-					} else if (date.getTime() > ignoreItemsPriorTo) {
+					} else if (date.getTime() > ignoreItemsPriorTo && entry.getLink() != null) {
 						log.fine("Adding link " + entry.getLink());
 			            CrawlURI link = curi.createCrawlURI(entry.getLink(), LinkContext.NAVLINK_MISC, Hop.NAVLINK);
 						link.getData().put(RssAttributeConstants.RSS_URI_TYPE, RssUriType.RSS_LINK);

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssExtractor.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssExtractor.java
@@ -18,21 +18,10 @@
  */
 package is.landsbokasafn.crawler.rss;
 
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.LAST_CONTENT_DIGEST;
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.LAST_FETCH_TIME;
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_URI_TYPE;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.StringReader;
-import java.util.Date;
-import java.util.List;
-import java.util.logging.Logger;
-
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.io.FeedException;
+import com.rometools.rome.io.SyndFeedInput;
 import org.apache.commons.io.IOUtils;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.extractor.Extractor;
@@ -40,8 +29,14 @@ import org.archive.modules.extractor.Hop;
 import org.archive.modules.extractor.LinkContext;
 import org.archive.modules.revisit.IdenticalPayloadDigestRevisit;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Logger;
 
-import com.rometools.rome.io.SyndFeedInput;
+import static is.landsbokasafn.crawler.rss.RssAttributeConstants.*;
 
 public class RssExtractor extends Extractor {
     private static final Logger log = Logger.getLogger(RssExtractor.class.getName());
@@ -88,7 +83,10 @@ public class RssExtractor extends Extractor {
 					} else if (date.getTime() > ignoreItemsPriorTo && entry.getLink() != null) {
 						log.fine("Adding link " + entry.getLink());
 			            CrawlURI link = curi.createCrawlURI(entry.getLink(), LinkContext.NAVLINK_MISC, Hop.NAVLINK);
-						link.getData().put(RssAttributeConstants.RSS_URI_TYPE, RssUriType.RSS_LINK);
+
+                        link.getData().put(RssAttributeConstants.RSS_URI_TYPE, RssUriType.RSS_LINK);
+                        link.getData().put(RssAttributeConstants.RSS_DATA, new RssEntry(entry));
+
 			            curi.getOutLinks().add(link);
 						if (date.getTime()>newMostRecent) {
 							newMostRecent = date.getTime();

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssFeed.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssFeed.java
@@ -18,19 +18,15 @@
  */
 package is.landsbokasafn.crawler.rss;
 
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.LAST_CONTENT_DIGEST;
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.LAST_FETCH_TIME;
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_IMPLIED_LINKS;
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_MOST_RECENTLY_SEEN;
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_URI_TYPE;
-
-import java.util.Date;
-import java.util.List;
-
 import org.apache.commons.httpclient.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.net.UURIFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+import java.util.List;
+
+import static is.landsbokasafn.crawler.rss.RssAttributeConstants.*;
 
 public class RssFeed {
 	String uri;

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssFrontierPreparer.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssFrontierPreparer.java
@@ -18,14 +18,14 @@
  */
 package is.landsbokasafn.crawler.rss;
 
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.*;
-
-import java.util.logging.Logger;
-
 import org.archive.crawler.prefetch.FrontierPreparer;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.ProcessResult;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.logging.Logger;
+
+import static is.landsbokasafn.crawler.rss.RssAttributeConstants.*;
 
 public class RssFrontierPreparer extends FrontierPreparer {
     private static final Logger log = Logger.getLogger(RssFrontierPreparer.class.getName());

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssInScopeDecideRule.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssInScopeDecideRule.java
@@ -18,11 +18,11 @@
  */
 package is.landsbokasafn.crawler.rss;
 
-import java.util.logging.Logger;
-
 import org.archive.modules.CrawlURI;
 import org.archive.modules.deciderules.DecideResult;
 import org.archive.modules.deciderules.DecideRule;
+
+import java.util.logging.Logger;
 
 /**
  * 

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssSite.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssSite.java
@@ -18,30 +18,20 @@
  */
 package is.landsbokasafn.crawler.rss;
 
-import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_SITE;	
-import static is.landsbokasafn.crawler.rss.RssSiteState.CRAWLING;
-import static is.landsbokasafn.crawler.rss.RssSiteState.UPDATING;
-import static is.landsbokasafn.crawler.rss.RssSiteState.WAITING;
-import static is.landsbokasafn.crawler.rss.RssSiteState.ENDED;
-import static org.archive.modules.fetcher.FetchStatusCodes.S_OUT_OF_SCOPE;
-import static org.joda.time.DateTimeConstants.MILLIS_PER_DAY;
-import static org.joda.time.DateTimeConstants.MILLIS_PER_HOUR;
-import static org.joda.time.DateTimeConstants.MILLIS_PER_MINUTE;
-import static org.joda.time.DateTimeConstants.MILLIS_PER_SECOND;
-
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.Logger;
-
 import org.archive.modules.CrawlURI;
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+import static is.landsbokasafn.crawler.rss.RssAttributeConstants.RSS_SITE;
+import static is.landsbokasafn.crawler.rss.RssSiteState.*;
+import static org.archive.modules.fetcher.FetchStatusCodes.S_OUT_OF_SCOPE;
+import static org.joda.time.DateTimeConstants.*;
 
 public class RssSite {
     private static final Logger log = Logger.getLogger(RssSite.class.getName());

--- a/src/main/java/is/landsbokasafn/crawler/rss/RssWarcWriterProcessor.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/RssWarcWriterProcessor.java
@@ -1,0 +1,61 @@
+package is.landsbokasafn.crawler.rss;
+
+import org.archive.format.warc.WARCConstants;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.io.warc.WARCWriter;
+import org.archive.modules.CrawlURI;
+import org.archive.modules.writer.WARCWriterProcessor;
+import org.archive.util.anvl.ANVLRecord;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+import static org.archive.format.warc.WARCConstants.TYPE;
+
+/**
+ * Created by abhijit on 04/11/15.
+ */
+public class RssWarcWriterProcessor extends WARCWriterProcessor {
+    @Override
+    protected URI writeMetadata(WARCWriter w, String timestamp, URI baseid, CrawlURI curi, ANVLRecord namedFields) throws IOException {
+        URI superret =  super.writeMetadata(w, timestamp, baseid, curi, namedFields);
+
+        // Get some metadata from the curi.
+        // TODO: Get all curi metadata.
+        // TODO: Use other than ANVL (or rename ANVL as NameValue or use
+        // RFC822 (commons-httpclient?).
+
+
+        if (curi.getData().containsKey(RssAttributeConstants.RSS_DATA)) {
+            RssEntry entry = (RssEntry) curi.getData().get(RssAttributeConstants.RSS_DATA);
+
+
+            WARCRecordInfo recordInfo = new WARCRecordInfo();
+            recordInfo.setType(WARCConstants.WARCRecordType.metadata);
+            recordInfo.setUrl(curi.toString());
+            recordInfo.setCreate14DigitDate(timestamp);
+            recordInfo.setMimetype(ANVLRecord.MIMETYPE);
+            recordInfo.setExtraHeaders(namedFields);
+            recordInfo.setEnforceLength(true);
+
+            recordInfo.setRecordId(qualifyRecordID(baseid, TYPE, WARCConstants.WARCRecordType.metadata.toString()));
+
+            ANVLRecord r = new ANVLRecord();
+
+            r.addLabel("rssinfo");
+            for (Map.Entry<String, String> e : entry.getRecords().entrySet())
+                r.addLabelValue(e.getKey(), e.getValue());
+
+
+            byte [] b = r.getUTF8Bytes();
+            recordInfo.setContentStream(new ByteArrayInputStream(b));
+            recordInfo.setContentLength((long) b.length);
+
+            w.writeRecord(recordInfo);
+        }
+
+        return superret;
+    }
+}

--- a/src/main/java/is/landsbokasafn/crawler/rss/db/DbConfigurationManager.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/db/DbConfigurationManager.java
@@ -1,23 +1,13 @@
 package is.landsbokasafn.crawler.rss.db;
 
-import is.landsbokasafn.crawler.rss.RssConfigurationManager;
-import is.landsbokasafn.crawler.rss.RssFeed;
-import is.landsbokasafn.crawler.rss.RssFrontierPreparer;
-import is.landsbokasafn.crawler.rss.RssSite;
-import is.landsbokasafn.crawler.rss.RssSiteState;
-
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-
+import is.landsbokasafn.crawler.rss.*;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.*;
+import java.util.logging.Logger;
 
 public class DbConfigurationManager implements RssConfigurationManager {
     private static final Logger log = Logger.getLogger(DbConfigurationManager.class.getName());

--- a/src/main/java/is/landsbokasafn/crawler/rss/db/Feed.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/db/Feed.java
@@ -1,20 +1,9 @@
 package is.landsbokasafn.crawler.rss.db;
 
+import javax.persistence.*;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 
 @Entity
 @Table(name="Feed")

--- a/src/main/java/is/landsbokasafn/crawler/rss/db/ImpliedPage.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/db/ImpliedPage.java
@@ -1,12 +1,6 @@
 package is.landsbokasafn.crawler.rss.db;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 
 @Entity

--- a/src/main/java/is/landsbokasafn/crawler/rss/db/Site.java
+++ b/src/main/java/is/landsbokasafn/crawler/rss/db/Site.java
@@ -1,15 +1,8 @@
 package is.landsbokasafn.crawler.rss.db;
 
+import javax.persistence.*;
 import java.util.Date;
 import java.util.Set;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
 
 @Entity
 @Table(name="Site")


### PR DESCRIPTION
This version adds the feed entry information with the CrawlURI as data, so that when the page is written to the archive, the feed entry can also be written along with it.
Also added support for later version of Rome. Enables better parsing of dates.